### PR TITLE
Removing unused external url

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -233,30 +233,6 @@ apps:
       key_vault_name: "acmedtssdsptl"
       name: "wildcard-hmcts-net"
     internalUrl: "https://tenable-sc.platform.hmcts.net/"
-  - name: "Splunk Search Head"
-    externalUrl: "https://splunk-sh.hmcts.net"
-    logoUrl: https://raw.githubusercontent.com/hmcts/azure-app-proxy/main/logos/splunk-search-head.png
-    userAssignmentRequired: false
-    appRoleAssignments:
-      - DTS CFT Developers
-      - DTS SDS Developers
-      - DTS Platform Operations
-    tls:
-      key_vault_name: "acmedtssdsptl"
-      name: "wildcard-hmcts-net"
-    internalUrl: "https://splunk-sh-prod-vm00.platform.hmcts.net:8000/"
-  - name: "Splunk Enterprise Security"
-    externalUrl: "https://splunk-es.hmcts.net"
-    logoUrl: https://raw.githubusercontent.com/hmcts/azure-app-proxy/main/logos/splunk-es-server.png
-    userAssignmentRequired: false
-    appRoleAssignments:
-      - DTS CFT Developers
-      - DTS SDS Developers
-      - DTS Platform Operations
-    tls:
-      key_vault_name: "acmedtssdsptl"
-      name: "wildcard-hmcts-net"
-    internalUrl: "https://splunk-es-prod-vm00.platform.hmcts.net:8000/"
   - name: "Backstage - Sandbox"
     logoUrl: https://raw.githubusercontent.com/hmcts/azure-app-proxy/main/logos/backstage.png
     userAssignmentRequired: false


### PR DESCRIPTION
### Change description
Reviewing existing App proxies, removing Splunk lingering related url as this service is now decommed.
